### PR TITLE
Fix DESTDIR, and add INSTALLDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
-DESTDIR := /tmp/libretro-core-info
+INSTALLDIR := /usr/share/libretro/info
 
 all:
 	@echo "Nothing to make for libretro-core-info."
 
 install:
-	mkdir -p $(DESTDIR)
-	cp -ar *.info $(DESTDIR)
+	mkdir -p $(DESTDIR)$(INSTALLDIR)
+	cp -a *.info $(DESTDIR)$(INSTALLDIR)
 
 update:
 	git clone git@github.com:libretro/libretro-super.git
 	cp -f libretro-super/dist/info/*.info .
+
+test-install: all
+	DESTDIR=/tmp/build $(MAKE) install


### PR DESCRIPTION
`DESTDIR` is the root of the file system, not where the package should be installed. This introduces a `INSTALLDIR` to allow changing install destination.

https://www.gnu.org/prep/standards/html_node/DESTDIR.html