### PR TITLE
Add file extension for TecToy SMS ROM extension

### DIFF
--- a/genesis_plus_gx_libretro.info
+++ b/genesis_plus_gx_libretro.info
@@ -1,6 +1,6 @@
 display_name = "Sega - MS/GG/MD/CD (Genesis Plus GX)"
 authors = "Charles McDonald|Eke-Eke"
-supported_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|gg|sg|68k|chd"
+supported_extensions = "mdx|md|smd|gen|bin|cue|iso|sms|bms|gg|sg|68k|chd"
 corename = "Genesis Plus GX"
 manufacturer = "Sega"
 categories = "Emulator"


### PR DESCRIPTION
Added .bms file extension for SMS ROMs seen on TecToy Megadrive 4. It's the same format as standard .sms ROMs, but uses a different extension, adding because it's an official thing. ~Red