### PR TITLE
Add rvz extension to Dolphin

### DIFF
--- a/dolphin_libretro.info
+++ b/dolphin_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Nintendo - GameCube / Wii (Dolphin)"
 authors = "Team Dolphin"
-supported_extensions = "gcm|iso|wbfs|ciso|gcz|elf|dol|dff|tgc|wad"
+supported_extensions = "gcm|iso|wbfs|ciso|gcz|rvz|elf|dol|dff|tgc|wad"
 corename = "Dolphin"
 categories = "Emulator"
 license = "GPLv2+"


### PR DESCRIPTION
Adds explicit support to the RVZ extension, used in newer versions of Dolphin including the latest Libretro cores.

https://dolphin-emu.org/blog/2020/07/05/dolphin-progress-report-may-and-june-2020/