### PR TITLE
moonlight core for lakka for nint switch

### DIFF
--- a/moonlight_libretro.info
+++ b/moonlight_libretro.info
@@ -1,0 +1,20 @@
+# Software Information
+display_name = "Moonlight"
+authors = "Rock88"
+supported_extensions = ""
+corename = "Moonlight"
+categories = "Streaming client"
+license = "GPLv3"
+permissions = ""
+display_version = "1.0"
+
+# Hardware Information
+systemname = "moonlight"
+manufacturer = "nVidia"
+
+# Libretro Features
+supports_no_game = "true"
+hw_render = "true"
+is_experimental = "true"
+
+description = "A port of the nVidia streaming client Moonlight. Currently only tested using Lakka running on Nintendo Switch."


### PR DESCRIPTION
added core info for an experimental moonlight core tested on Nintendo Switch Lakka