### PR TITLE
Add zip to fuse

### DIFF
--- a/fuse_libretro.info
+++ b/fuse_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sinclair - ZX Spectrum (Fuse)"
 authors = "Team Fuse"
-supported_extensions = "tzx|tap|z80|rzx|scl|trd|dsk"
+supported_extensions = "tzx|tap|z80|rzx|scl|trd|dsk|zip"
 corename = "Fuse"
 categories = "Emulator"
 license = "GPLv3"


### PR DESCRIPTION
Add zip as acceptable extension for fuse.  Tested by manually loading a zip file, and it loads without issue:
```
/Applications/RetroArch.app/Contents/MacOS/RetroArch -L "/Users/xxx/Documents/RetroArch/cores/fuse_libretro.dylib" "/Users/xxx/Downloads/robocop3.zip"
[INFO] === Build =======================================
[INFO] CPU Model Name: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
[INFO] Capabilities:  MMX MMXEXT SSE SSE2 SSE3 SSSE3 SSE4 SSE4.2 AES AVX AVX2
[INFO] Built: Mar 28 2022
[INFO] Version: 1.10.2
[INFO] =================================================
[INFO] [Input]: Found input driver: "cocoa".
[INFO] [Core]: Loading dynamic libretro core from: "/Users/xxx/Documents/RetroArch/cores/fuse_libretro.dylib"
[INFO] [Overrides]: No core-specific overrides found at "/Users/xxx/Library/Application Support/RetroArch/config/fuse/fuse.cfg".
[INFO] [Overrides]: No content-dir-specific overrides found at "/Users/xxx/Library/Application Support/RetroArch/config/fuse/Downloads.cfg".
[INFO] [Overrides]: No game-specific overrides found at "/Users/xxx/Library/Application Support/RetroArch/config/fuse/robocop3.cfg".
[INFO] [Environ]: SET_VARIABLES.
[INFO] [Environ]: SET_CONTROLLER_INFO.
[INFO] [Remaps]: Remap directory: "/Users/xxx/Library/Application Support/RetroArch/config/remaps".
[INFO] [Overrides]: Redirecting save file to "/Users/xxx/Documents/RetroArch/saves/robocop3.srm".
[INFO] [Overrides]: Redirecting save state to "/Users/xxx/Documents/RetroArch/states/robocop3.state".
[INFO] [Environ]: GET_LOG_INTERFACE.
[libretro INFO] port 0 device 00000101
[libretro INFO] port 1 device 00000201
[libretro INFO] port 2 device 00000103
[INFO] [Content]: Loading content file: "/Users/xxx/Downloads/robocop3.zip#Robocop 3 (1992)(Ocean)[128K].z80".
[INFO] [Content]: Did not find a valid content patch.
[INFO] [Content]: CRC32: 0x21b5c6b7.
[libretro INFO] 
+------------------------------------------+
|              FUSE-LIBRETRO               |
|    ____    _   _   ___   _      ____     |
|   | __ )  | | | | |_ _| | |    |  _ \    |
|   |  _ \  | | | |  | |  | |    | | | |   |
|   | |_) | | |_| |  | |  | |__  | |_| |   |
|   |____/   \___/  |___| |____| |____/    |
|                                          |
| 042f8a9d4758d2d9a47ae064a1fe76b73ad9282c |
+------------------------------------------+

...
```