### PR TITLE
px68k_libretro.info: Remove invalid extension (.zip)

### DIFF
--- a/px68k_libretro.info
+++ b/px68k_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Sharp - X68000 (PX68k)"
 authors = "hissorii"
-supported_extensions = "dim|zip|img|d88|88d|hdm|dup|2hd|xdf|hdf|cmd|m3u"
+supported_extensions = "dim|img|d88|88d|hdm|dup|2hd|xdf|hdf|cmd|m3u"
 corename = "PX68k"
 license = "Custom Non-Commercial"
 permissions = ""


### PR DESCRIPTION
core should not be able to directly handle .zip files.