### PR TITLE
Updated version line to latest and added bios information for PSP PSX BIOS

### DIFF
--- a/pcsx_rearmed_libretro.info
+++ b/pcsx_rearmed_libretro.info
@@ -4,7 +4,7 @@ supported_extensions = "bin|cue|img|mdf|pbp|toc|cbn|m3u|ccd|chd|iso|exe"
 corename = "PCSX-ReARMed"
 license = "GPLv2"
 permissions = "dynarec"
-display_version = "r21"
+display_version = "r24"
 categories = "Emulator"
 
 # Hardware Information
@@ -29,7 +29,7 @@ disk_control = "true"
 is_experimental = "false"
 
 # Firmware / BIOS
-firmware_count = 3
+firmware_count = 4
 firmware0_desc = "scph5500.bin (PS1 JP BIOS)"
 firmware0_path = "scph5500.bin"
 firmware0_opt = "true"
@@ -39,6 +39,9 @@ firmware1_opt = "true"
 firmware2_desc = "scph5502.bin (PS1 EU BIOS)"
 firmware2_path = "scph5502.bin"
 firmware2_opt = "true"
-notes = "(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050"
+firmware3_desc = "psponpsx660.bin (PSP PSX Emu BIOS)"
+firmware3_path = "psxonpsp660.bin"
+firmware3_opt = "true"
+notes = "(!) scph5500.bin (md5): 8dd7d5296a650fac7319bce665a6a53c|(!) scph5501.bin (md5): 490f666e1afb15b7362b406ed1cea246|(!) scph5502.bin (md5): 32736f17079d0b2b7024407c39bd3050|(!) psxonpsp660.bin (md5): c53ca5908936d412331790f4426c6c33"
 
 description = "A port of the PCSX-ReARMed fork to libretro. This emulator is a technical marvel and runs incredibly well on 32-bit ARM CPUs, though it is also a good choice for other low-powered hardware that cannot run Beetle-PSX/-HW or Swanstation at full speed. However, this core has no support for increased internal resolution, texture filtering, etc., so users who want those features would be better served by the other cores."


### PR DESCRIPTION
Updated version line to reflect latest r24 version as r21 is quite old.

Changed firmware count to 4 in order to accommodate additional bios file.

Added "psponpsx660.bin" information. The PSP BIOS isn't region locked so it allows for better ease of use.
