### PR TITLE
Create uae4all_libretro.info

### DIFF
--- a/uae4all_libretro.info
+++ b/uae4all_libretro.info
@@ -1,0 +1,39 @@
+# Software Information
+display_name = "Commodore - Amiga 500(UAE4ALL)"
+categories = "Emulator"
+authors = "Chips-fr"
+corename = "UAE4ALL"
+supported_extensions = "adf|adz|zip"
+license = "GPLv2"
+permissions = ""
+display_version = "v0.7"
+
+# Hardware Information
+manufacturer = "Commodore"
+systemname = "Amiga"
+systemid = "commodore_amiga"
+
+# Libretro Features
+database = "Commodore - Amiga"
+supports_no_game = "false"
+libretro_saves = "false"
+savestate = "false"
+savestate_features = "serialized"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "false"
+core_options = "true"
+load_subsystem = "false"
+hw_render = "false"
+needs_fullpath = "true"
+disk_control = "true"
+is_experimental = "false"
+
+# Firmware
+firmware_count = 1
+firmware0_desc = "kick34005.A500 (Amiga 500 BIOS, Kickstart v1.3 Rev. 34.005)"
+firmware0_path = "kick34005.A500"
+firmware0_opt = "false"
+notes = "(!) kick34005.A500 (md5): 82a21c1890cae844b3df741f2762d48d"
+
+description = "An old fork of the uae4all Amiga emulator, ported to libretro. It emulates most Commodore Amiga 500 hardware with OSC 1MB Chip. The core has no built-in Kickstart, so you need to provide one. This core is intended only for use on low-powered hardware and is in the development stage"


### PR DESCRIPTION
Port of very fast AMIGA 500 emulator aka "UAE4ALL" to libretro via https://github.com/Chips-fr/uae4all-rpi . No built-in AROS kickstart rom cuz there is no fastmem in this emulator, so you have to provide one.

some downstream projects use it like:
- [Recalbox](https://wiki.recalbox.com/en/emulators/computers/amiga-600/libretro-uae4all) for RPI0 and RPI1
- MiyooCFW with official RA frontend for low-end ARMv5

No savestate support so I would say it still in BETA phase, but works really well on the weakest hardware. Kudoz to @Chips-fr for porting!