### PR TITLE
Add trident_libretro.info for Nintendo 3DS (Trident) core

### DIFF
--- a/trident_libretro.info
+++ b/trident_libretro.info
@@ -1,0 +1,34 @@
+# Software Information
+display_name = "Nintendo - 3DS (Trident)"
+authors = "Trident Contributors"
+supported_extensions = "3ds|3dsx|elf|axf|cci|cxi|app|ncch"
+corename = "Trident"
+categories = "Emulator"
+license = "GPLv3"
+permissions = ""
+display_version = "Git"
+
+# Hardware Information
+manufacturer = "Nintendo"
+systemname = "3DS"
+systemid = "3ds"
+
+# Libretro Information
+database = "Nintendo - Nintendo 3DS"
+supports_no_game = "false"
+savestate = "true"
+savestate_features = "basic"
+cheats = "false"
+input_descriptors = "true"
+memory_descriptors = "true"
+libretro_saves = "true"
+core_options = "true"
+core_options_version = "1.0"
+load_subsystem = "false"
+hw_render = "true"
+required_hw_api = "OpenGL Core >= 4.1 | OpenGL ES >= 3.0"
+needs_fullpath = "true"
+disk_control = "false"
+is_experimental = "false"
+
+description = "A 3DS libretro core powered by the Panda3DS emulation engine."


### PR DESCRIPTION
Adds core info for the Trident 3DS libretro core.

Trident is a Nintendo 3DS libretro core built on the Panda3DS emulation engine. It supports 6 platforms (Windows, Linux, macOS ARM64/x64, Android, iOS) and includes RetroAchievements memory descriptor support.

Source: https://github.com/DanAlexMorton/3dsTrident